### PR TITLE
Updating support requirement.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.2.*",
+        "illuminate/support": "4.3.*",
         "patchwork/utf8": "1.1.*"
     },
     "autoload": {


### PR DESCRIPTION
This works as is with laravel 4.3.  Hoping you can use this to create an optional package ref for those on 4.3.
